### PR TITLE
Improve Debug impl of Duration

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,4 +1,5 @@
 use core::{
+    fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
     time,
 };
@@ -19,7 +20,7 @@ use super::pair_and_then;
 /// [`Add`]: std::ops::Add
 /// [`Sub`]: std::ops::Sub
 /// [`ops`]: std::ops
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Duration(pub(crate) Option<time::Duration>);
 
 impl Duration {
@@ -175,6 +176,12 @@ impl Duration {
 
 // =============================================================================
 // Trait implementations
+
+impl fmt::Debug for Duration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
 
 impl Default for Duration {
     fn default() -> Self {

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -160,171 +160,137 @@ fn correct_sum() {
 }
 */
 
-/* TODO duration_debug_impl https://github.com/rust-lang/rust/pull/50364
+// duration_debug_impl https://github.com/rust-lang/rust/pull/50364
+
 #[test]
 fn debug_formatting_extreme_values() {
     assert_eq!(
-        format!(
-            "{:?}",
-            Duration::new(18_446_744_073_709_551_615, 123_456_789)
-        ),
-        "18446744073709551615.123456789s"
+        format!("{:?}", Duration::new(18_446_744_073_709_551_615, 123_456_789)),
+        "Some(18446744073709551615.123456789s)"
     );
 }
 
 #[test]
 fn debug_formatting_secs() {
-    assert_eq!(format!("{:?}", Duration::new(7, 000_000_000)), "7s");
-    assert_eq!(format!("{:?}", Duration::new(7, 100_000_000)), "7.1s");
-    assert_eq!(format!("{:?}", Duration::new(7, 000_010_000)), "7.00001s");
-    assert_eq!(
-        format!("{:?}", Duration::new(7, 000_000_001)),
-        "7.000000001s"
-    );
-    assert_eq!(
-        format!("{:?}", Duration::new(7, 123_456_789)),
-        "7.123456789s"
-    );
+    assert_eq!(format!("{:?}", Duration::new(7, 000_000_000)), "Some(7s)");
+    assert_eq!(format!("{:?}", Duration::new(7, 100_000_000)), "Some(7.1s)");
+    assert_eq!(format!("{:?}", Duration::new(7, 000_010_000)), "Some(7.00001s)");
+    assert_eq!(format!("{:?}", Duration::new(7, 000_000_001)), "Some(7.000000001s)");
+    assert_eq!(format!("{:?}", Duration::new(7, 123_456_789)), "Some(7.123456789s)");
 
-    assert_eq!(format!("{:?}", Duration::new(88, 000_000_000)), "88s");
-    assert_eq!(format!("{:?}", Duration::new(88, 100_000_000)), "88.1s");
-    assert_eq!(format!("{:?}", Duration::new(88, 000_010_000)), "88.00001s");
-    assert_eq!(
-        format!("{:?}", Duration::new(88, 000_000_001)),
-        "88.000000001s"
-    );
-    assert_eq!(
-        format!("{:?}", Duration::new(88, 123_456_789)),
-        "88.123456789s"
-    );
+    assert_eq!(format!("{:?}", Duration::new(88, 000_000_000)), "Some(88s)");
+    assert_eq!(format!("{:?}", Duration::new(88, 100_000_000)), "Some(88.1s)");
+    assert_eq!(format!("{:?}", Duration::new(88, 000_010_000)), "Some(88.00001s)");
+    assert_eq!(format!("{:?}", Duration::new(88, 000_000_001)), "Some(88.000000001s)");
+    assert_eq!(format!("{:?}", Duration::new(88, 123_456_789)), "Some(88.123456789s)");
 
-    assert_eq!(format!("{:?}", Duration::new(999, 000_000_000)), "999s");
-    assert_eq!(format!("{:?}", Duration::new(999, 100_000_000)), "999.1s");
-    assert_eq!(
-        format!("{:?}", Duration::new(999, 000_010_000)),
-        "999.00001s"
-    );
-    assert_eq!(
-        format!("{:?}", Duration::new(999, 000_000_001)),
-        "999.000000001s"
-    );
-    assert_eq!(
-        format!("{:?}", Duration::new(999, 123_456_789)),
-        "999.123456789s"
-    );
+    assert_eq!(format!("{:?}", Duration::new(999, 000_000_000)), "Some(999s)");
+    assert_eq!(format!("{:?}", Duration::new(999, 100_000_000)), "Some(999.1s)");
+    assert_eq!(format!("{:?}", Duration::new(999, 000_010_000)), "Some(999.00001s)");
+    assert_eq!(format!("{:?}", Duration::new(999, 000_000_001)), "Some(999.000000001s)");
+    assert_eq!(format!("{:?}", Duration::new(999, 123_456_789)), "Some(999.123456789s)");
 }
 
 #[test]
 fn debug_formatting_millis() {
-    assert_eq!(format!("{:?}", Duration::new(0, 7_000_000)), "7ms");
-    assert_eq!(format!("{:?}", Duration::new(0, 7_100_000)), "7.1ms");
-    assert_eq!(format!("{:?}", Duration::new(0, 7_000_001)), "7.000001ms");
-    assert_eq!(format!("{:?}", Duration::new(0, 7_123_456)), "7.123456ms");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_000_000)), "Some(7ms)");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_100_000)), "Some(7.1ms)");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_000_001)), "Some(7.000001ms)");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_123_456)), "Some(7.123456ms)");
 
-    assert_eq!(format!("{:?}", Duration::new(0, 88_000_000)), "88ms");
-    assert_eq!(format!("{:?}", Duration::new(0, 88_100_000)), "88.1ms");
-    assert_eq!(format!("{:?}", Duration::new(0, 88_000_001)), "88.000001ms");
-    assert_eq!(format!("{:?}", Duration::new(0, 88_123_456)), "88.123456ms");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_000_000)), "Some(88ms)");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_100_000)), "Some(88.1ms)");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_000_001)), "Some(88.000001ms)");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_123_456)), "Some(88.123456ms)");
 
-    assert_eq!(format!("{:?}", Duration::new(0, 999_000_000)), "999ms");
-    assert_eq!(format!("{:?}", Duration::new(0, 999_100_000)), "999.1ms");
-    assert_eq!(
-        format!("{:?}", Duration::new(0, 999_000_001)),
-        "999.000001ms"
-    );
-    assert_eq!(
-        format!("{:?}", Duration::new(0, 999_123_456)),
-        "999.123456ms"
-    );
+    assert_eq!(format!("{:?}", Duration::new(0, 999_000_000)), "Some(999ms)");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_100_000)), "Some(999.1ms)");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_000_001)), "Some(999.000001ms)");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_123_456)), "Some(999.123456ms)");
 }
 
 #[test]
 fn debug_formatting_micros() {
-    assert_eq!(format!("{:?}", Duration::new(0, 7_000)), "7µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 7_100)), "7.1µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 7_001)), "7.001µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 7_123)), "7.123µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_000)), "Some(7µs)");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_100)), "Some(7.1µs)");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_001)), "Some(7.001µs)");
+    assert_eq!(format!("{:?}", Duration::new(0, 7_123)), "Some(7.123µs)");
 
-    assert_eq!(format!("{:?}", Duration::new(0, 88_000)), "88µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 88_100)), "88.1µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 88_001)), "88.001µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 88_123)), "88.123µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_000)), "Some(88µs)");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_100)), "Some(88.1µs)");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_001)), "Some(88.001µs)");
+    assert_eq!(format!("{:?}", Duration::new(0, 88_123)), "Some(88.123µs)");
 
-    assert_eq!(format!("{:?}", Duration::new(0, 999_000)), "999µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 999_100)), "999.1µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 999_001)), "999.001µs");
-    assert_eq!(format!("{:?}", Duration::new(0, 999_123)), "999.123µs");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_000)), "Some(999µs)");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_100)), "Some(999.1µs)");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_001)), "Some(999.001µs)");
+    assert_eq!(format!("{:?}", Duration::new(0, 999_123)), "Some(999.123µs)");
 }
 
 #[test]
 fn debug_formatting_nanos() {
-    assert_eq!(format!("{:?}", Duration::new(0, 0)), "0ns");
-    assert_eq!(format!("{:?}", Duration::new(0, 1)), "1ns");
-    assert_eq!(format!("{:?}", Duration::new(0, 88)), "88ns");
-    assert_eq!(format!("{:?}", Duration::new(0, 999)), "999ns");
+    assert_eq!(format!("{:?}", Duration::new(0, 0)), "Some(0ns)");
+    assert_eq!(format!("{:?}", Duration::new(0, 1)), "Some(1ns)");
+    assert_eq!(format!("{:?}", Duration::new(0, 88)), "Some(88ns)");
+    assert_eq!(format!("{:?}", Duration::new(0, 999)), "Some(999ns)");
 }
 
 #[test]
 fn debug_formatting_precision_zero() {
-    assert_eq!(format!("{:.0?}", Duration::new(0, 0)), "0ns");
-    assert_eq!(format!("{:.0?}", Duration::new(0, 123)), "123ns");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 0)), "Some(0ns)");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 123)), "Some(123ns)");
 
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_001)), "1µs");
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_499)), "1µs");
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_500)), "2µs");
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_999)), "2µs");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_001)), "Some(1µs)");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_499)), "Some(1µs)");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_500)), "Some(2µs)");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_999)), "Some(2µs)");
 
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_000_001)), "1ms");
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_499_999)), "1ms");
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_500_000)), "2ms");
-    assert_eq!(format!("{:.0?}", Duration::new(0, 1_999_999)), "2ms");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_000_001)), "Some(1ms)");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_499_999)), "Some(1ms)");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_500_000)), "Some(2ms)");
+    assert_eq!(format!("{:.0?}", Duration::new(0, 1_999_999)), "Some(2ms)");
 
-    assert_eq!(format!("{:.0?}", Duration::new(1, 000_000_001)), "1s");
-    assert_eq!(format!("{:.0?}", Duration::new(1, 499_999_999)), "1s");
-    assert_eq!(format!("{:.0?}", Duration::new(1, 500_000_000)), "2s");
-    assert_eq!(format!("{:.0?}", Duration::new(1, 999_999_999)), "2s");
+    assert_eq!(format!("{:.0?}", Duration::new(1, 000_000_001)), "Some(1s)");
+    assert_eq!(format!("{:.0?}", Duration::new(1, 499_999_999)), "Some(1s)");
+    assert_eq!(format!("{:.0?}", Duration::new(1, 500_000_000)), "Some(2s)");
+    assert_eq!(format!("{:.0?}", Duration::new(1, 999_999_999)), "Some(2s)");
 }
 
 #[test]
 fn debug_formatting_precision_two() {
-    assert_eq!(format!("{:.2?}", Duration::new(0, 0)), "0.00ns");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 123)), "123.00ns");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 0)), "Some(0.00ns)");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 123)), "Some(123.00ns)");
 
-    assert_eq!(format!("{:.2?}", Duration::new(0, 1_000)), "1.00µs");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 7_001)), "7.00µs");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 7_100)), "7.10µs");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 7_109)), "7.11µs");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 7_199)), "7.20µs");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 1_999)), "2.00µs");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 1_000)), "Some(1.00µs)");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 7_001)), "Some(7.00µs)");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 7_100)), "Some(7.10µs)");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 7_109)), "Some(7.11µs)");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 7_199)), "Some(7.20µs)");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 1_999)), "Some(2.00µs)");
 
-    assert_eq!(format!("{:.2?}", Duration::new(0, 1_000_000)), "1.00ms");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 3_001_000)), "3.00ms");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 3_100_000)), "3.10ms");
-    assert_eq!(format!("{:.2?}", Duration::new(0, 1_999_999)), "2.00ms");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 1_000_000)), "Some(1.00ms)");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 3_001_000)), "Some(3.00ms)");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 3_100_000)), "Some(3.10ms)");
+    assert_eq!(format!("{:.2?}", Duration::new(0, 1_999_999)), "Some(2.00ms)");
 
-    assert_eq!(format!("{:.2?}", Duration::new(1, 000_000_000)), "1.00s");
-    assert_eq!(format!("{:.2?}", Duration::new(4, 001_000_000)), "4.00s");
-    assert_eq!(format!("{:.2?}", Duration::new(2, 100_000_000)), "2.10s");
-    assert_eq!(format!("{:.2?}", Duration::new(2, 104_990_000)), "2.10s");
-    assert_eq!(format!("{:.2?}", Duration::new(2, 105_000_000)), "2.11s");
-    assert_eq!(format!("{:.2?}", Duration::new(8, 999_999_999)), "9.00s");
+    assert_eq!(format!("{:.2?}", Duration::new(1, 000_000_000)), "Some(1.00s)");
+    assert_eq!(format!("{:.2?}", Duration::new(4, 001_000_000)), "Some(4.00s)");
+    assert_eq!(format!("{:.2?}", Duration::new(2, 100_000_000)), "Some(2.10s)");
+    assert_eq!(format!("{:.2?}", Duration::new(2, 104_990_000)), "Some(2.10s)");
+    assert_eq!(format!("{:.2?}", Duration::new(2, 105_000_000)), "Some(2.11s)");
+    assert_eq!(format!("{:.2?}", Duration::new(8, 999_999_999)), "Some(9.00s)");
 }
 
 #[test]
 fn debug_formatting_precision_high() {
-    assert_eq!(format!("{:.5?}", Duration::new(0, 23_678)), "23.67800µs");
+    assert_eq!(format!("{:.5?}", Duration::new(0, 23_678)), "Some(23.67800µs)");
 
-    assert_eq!(
-        format!("{:.9?}", Duration::new(1, 000_000_000)),
-        "1.000000000s"
-    );
-    assert_eq!(
-        format!("{:.10?}", Duration::new(4, 001_000_000)),
-        "4.0010000000s"
-    );
-    assert_eq!(
-        format!("{:.20?}", Duration::new(4, 001_000_000)),
-        "4.00100000000000000000s"
-    );
+    assert_eq!(format!("{:.9?}", Duration::new(1, 000_000_000)), "Some(1.000000000s)");
+    assert_eq!(format!("{:.10?}", Duration::new(4, 001_000_000)), "Some(4.0010000000s)");
+    assert_eq!(format!("{:.20?}", Duration::new(4, 001_000_000)), "Some(4.00100000000000000000s)");
 }
-*/
+
+#[test]
+fn debug_formatting_none() {
+    assert_eq!(format!("{:?}", Duration::new(0, 0) - Duration::new(0, 1)), "None");
+}


### PR DESCRIPTION
`Duration(Some(num))` -> `Some(num)`, `Duration(None)` -> `None`

This causes `easytime::Duration` to be printed the same as `std::time::Duration::checked_*`'s result.