### PR TITLE
impl TryFrom for Instant and Duration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ matrix:
   include:
     # This is the minimum Rust version supported by easytime.
     # When updating this, the reminder to update the minimum required version in README.md.
-    - rust: 1.33.0
-      script:
-        - cargo test --tests --no-default-features
     - rust: 1.34.0
 
     - rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Implement `TryFrom` for `easytime::Instant` and `easytime::Duration`. With this change, the minimum required version of `easytime` with `--no-default-features` goes up to Rust 1.34 (the minimum required version of the default feature has not changed).
+
 * Changed the `Debug` implementation of `easytime::Duration` to display the same as the result of `std::time::Duration::checked_*`.
 
 # 0.1.2 - 2019-03-01

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add this to your `Cargo.toml`:
 easytime = "0.1"
 ```
 
-The current version of easytime requires Rust 1.34 or later.
+The current easytime requires Rust 1.34 or later.
 
 ## Examples
 
@@ -67,8 +67,7 @@ fn foo(secs: u64, nanos: u32, instant: Instant) -> Option<Duration> {
 
 * **`std`** *(enabled by default)*
   * Enable to use [`easytime::Instant`].
-  * This requires Rust 1.34 or later.
-  * If disabled this feature, easytime can compile with Rust 1.33.
+  * If disabled this feature, `easytime` can be used in `no_std` environments.
 
 ## License
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,10 +1,11 @@
 use core::{
+    convert::TryFrom,
     fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
     time,
 };
 
-use super::pair_and_then;
+use super::{pair_and_then, TryFromTimeError};
 
 /// A `Duration` type to represent a span of time, typically used for system
 /// timeouts.
@@ -192,6 +193,14 @@ impl Default for Duration {
 impl From<time::Duration> for Duration {
     fn from(dur: time::Duration) -> Self {
         Self(Some(dur))
+    }
+}
+
+impl TryFrom<Duration> for time::Duration {
+    type Error = TryFromTimeError;
+
+    fn try_from(dur: Duration) -> Result<Self, TryFromTimeError> {
+        dur.into_inner().ok_or_else(|| TryFromTimeError(()))
     }
 }
 

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -1,9 +1,10 @@
 use std::{
+    convert::TryFrom,
     ops::{Add, AddAssign, Sub, SubAssign},
     time,
 };
 
-use super::{pair_and_then, Duration};
+use super::{pair_and_then, Duration, TryFromTimeError};
 
 /// A measurement of a monotonically nondecreasing clock.
 /// Opaque and useful only with `Duration`.
@@ -110,6 +111,14 @@ impl Instant {
 impl From<time::Instant> for Instant {
     fn from(instant: time::Instant) -> Self {
         Self(Some(instant))
+    }
+}
+
+impl TryFrom<Instant> for time::Instant {
+    type Error = TryFromTimeError;
+
+    fn try_from(instant: Instant) -> Result<Self, TryFromTimeError> {
+        instant.into_inner().ok_or_else(|| TryFromTimeError(()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,7 @@
 //!
 //! * **`std`** *(enabled by default)*
 //!   * Enable to use [`easytime::Instant`].
-//!   * This requires Rust 1.34 or later.
-//!   * If disabled this feature, easytime can compile with Rust 1.33.
+//!   * If disabled this feature, `easytime` can be used in `no_std` environments.
 //!
 
 #![doc(html_root_url = "https://docs.rs/easytime/0.1.2")]
@@ -71,6 +70,27 @@ pub use duration::Duration;
 mod instant;
 #[cfg(feature = "std")]
 pub use instant::Instant;
+
+use core::fmt;
+
+// =============================================================================
+// TryFromTimeError
+
+/// The error type returned when a conversion from `easytime` types to `std::time` types fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TryFromTimeError(());
+
+impl fmt::Display for TryFromTimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid arithmetic attempted on instants or durations")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TryFromTimeError {}
+
+// =============================================================================
+// Utilities
 
 fn pair_and_then<A, B, C, F>(x: Option<A>, y: Option<B>, f: F) -> Option<C>
 where


### PR DESCRIPTION
With this change, the minimum required version of `easytime` with `--no-default-features` goes up to Rust 1.34 (the minimum required version of the default feature has not changed).