### PR TITLE
Use real checked_duration_since if Rust 1.39 and later

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,27 @@
+use std::{env, process::Command};
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let minor = match rustc_minor_version() {
+        Some(x) => x,
+        None => return,
+    };
+
+    if minor >= 39 {
+        println!("cargo:rustc-cfg=stable_1_39");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    env::var_os("RUSTC")
+        .and_then(|rustc| Command::new(rustc).arg("--version").output().ok())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .and_then(|version| {
+            let mut pieces = version.split('.');
+            if pieces.next() != Some("rustc 1") {
+                return None;
+            }
+            pieces.next()?.parse().ok()
+        })
+}

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -69,7 +69,7 @@ impl Duration {
     /// [`subsec_nanos`]: #method.subsec_nanos
     #[inline]
     pub fn as_secs(&self) -> Option<u64> {
-        self.0.map(|d| d.as_secs())
+        self.0.as_ref().map(time::Duration::as_secs)
     }
 
     /// Returns the fractional part of this `Duration`, in whole milliseconds.
@@ -79,7 +79,7 @@ impl Duration {
     /// fractional portion of a second (i.e., it is less than one thousand).
     #[inline]
     pub fn subsec_millis(&self) -> Option<u32> {
-        self.0.map(|d| d.subsec_millis())
+        self.0.as_ref().map(time::Duration::subsec_millis)
     }
 
     /// Returns the fractional part of this `Duration`, in whole microseconds.
@@ -89,7 +89,7 @@ impl Duration {
     /// fractional portion of a second (i.e., it is less than one million).
     #[inline]
     pub fn subsec_micros(&self) -> Option<u32> {
-        self.0.map(|d| d.subsec_micros())
+        self.0.as_ref().map(time::Duration::subsec_micros)
     }
 
     /// Returns the fractional part of this `Duration`, in nanoseconds.
@@ -99,28 +99,29 @@ impl Duration {
     /// fractional portion of a second (i.e., it is less than one billion).
     #[inline]
     pub fn subsec_nanos(&self) -> Option<u32> {
-        self.0.map(|d| d.subsec_nanos())
+        self.0.as_ref().map(time::Duration::subsec_nanos)
     }
 
     /// Returns the total number of whole milliseconds contained by this `Duration`.
     #[inline]
     pub fn as_millis(&self) -> Option<u128> {
-        self.0.map(|d| d.as_millis())
+        self.0.as_ref().map(time::Duration::as_millis)
     }
 
     /// Returns the total number of whole microseconds contained by this `Duration`.
     #[inline]
     pub fn as_micros(&self) -> Option<u128> {
-        self.0.map(|d| d.as_micros())
+        self.0.as_ref().map(time::Duration::as_micros)
     }
 
     /// Returns the total number of nanoseconds contained by this `Duration`.
     #[inline]
     pub fn as_nanos(&self) -> Option<u128> {
-        self.0.map(|d| d.as_nanos())
+        self.0.as_ref().map(time::Duration::as_nanos)
     }
 
     // TODO: duration_float https://github.com/rust-lang/rust/issues/54361
+    // TODO: div_duration https://github.com/rust-lang/rust/issues/63139
 }
 
 // =============================================================================

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -36,6 +36,13 @@ impl Instant {
     }
 
     /// Returns the amount of time elapsed from another instant to this one.
+    #[cfg(stable_1_39)]
+    pub fn duration_since(&self, earlier: Self) -> Duration {
+        Duration(pair_and_then(self.0.as_ref(), earlier.0, time::Instant::checked_duration_since))
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one.
+    #[cfg(not(stable_1_39))]
     pub fn duration_since(&self, earlier: Self) -> Duration {
         Duration(pair_and_then(self.0.as_ref(), earlier.0, |this, earlier| {
             // https://github.com/rust-lang/rust/pull/58395
@@ -116,7 +123,7 @@ impl Add<Duration> for Instant {
     type Output = Self;
 
     fn add(self, other: Duration) -> Self {
-        Self(pair_and_then(self.0, other.0, |this, other| this.checked_add(other)))
+        Self(pair_and_then(self.0.as_ref(), other.0, time::Instant::checked_add))
     }
 }
 
@@ -144,7 +151,7 @@ impl Sub<Duration> for Instant {
     type Output = Self;
 
     fn sub(self, other: Duration) -> Self {
-        Self(pair_and_then(self.0, other.0, |this, other| this.checked_sub(other)))
+        Self(pair_and_then(self.0.as_ref(), other.0, time::Instant::checked_sub))
     }
 }
 

--- a/tests/instant.rs
+++ b/tests/instant.rs
@@ -67,7 +67,10 @@ fn instant_math_is_associative() {
 
 #[test]
 fn instant_duration_untrusted() {
-    let a = Instant::now();
-    let ret = (a - Duration::new(1, 0)).duration_since(a);
-    assert_eq!(ret.into_inner(), None);
+    let now = Instant::now();
+    let earlier = now - Duration::new(1, 0);
+    let later = now + Duration::new(1, 0);
+    assert_eq!(earlier.duration_since(now).into_inner(), None);
+    assert_eq!(later.duration_since(now), Duration::new(1, 0));
+    assert_eq!(now.duration_since(now), Duration::new(0, 0));
 }


### PR DESCRIPTION
`checked_duration_since` has been stabilized in Rust 1.39.