### PR TITLE
Add duration_float methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+- Add `Duration::{as_secs_f64, as_secs_f32, from_secs_f64, from_secs_f32,
+  mul_f64, mul_f32, div_f64, div_f32}` methods.
+  They are based on [`duration_float`](https://github.com/rust-lang/rust/issues/54361)
+  feature of the standard library that stabilized on Rust 1.38.
+
 - Make `Duration::{as_secs, subsec_millis, subsec_micros, subsec_nanos,
   as_millis, as_micros, as_nanos, is_some, is_none, unwrap_or}` const function
   on rustc 1.46+.
 
-- Make `Instant::{is_some, is_none, unwrap_or}` const function on rustc 1.46+.
+- Make `Instant::{is_some, is_none, unwrap_or}` const function on Rust 1.46+.
 
 - Implement `TryFrom` for `easytime::Instant` and `easytime::Duration`. With
   this change, the minimum required version of `easytime` with `--no-default-features` goes up to Rust 1.34 (the minimum required version of the default feature has not changed).

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ fn foo(secs: u64, nanos: u32, instant: Instant) -> Option<Duration> {
     let now = Instant::now();
 
     let secs = Duration::from_secs(secs);
-    let nanos = Duration::from_nanos(u64::from(nanos));
+    let nanos = Duration::from_nanos(nanos as u64);
 
     let dur = secs.checked_add(nanos)?;
     now.checked_duration_since(instant)?.checked_sub(dur)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //!     let now = Instant::now();
 //!
 //!     let secs = Duration::from_secs(secs);
-//!     let nanos = Duration::from_nanos(u64::from(nanos));
+//!     let nanos = Duration::from_nanos(nanos as u64);
 //!
 //!     let dur = secs.checked_add(nanos)?;
 //!     now.checked_duration_since(instant)?.checked_sub(dur)


### PR DESCRIPTION
This adds `Duration::{as_secs_f64, as_secs_f32, from_secs_f64, from_secs_f32, mul_f64, mul_f32, div_f64, div_f32}`  methods.

They are based on [`duration_float`](https://github.com/rust-lang/rust/issues/54361) feature of the standard library that stabilized on Rust 1.38.