### PR TITLE
Add Duration::{ZERO, MAX, is_zero} methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `Duration::{ZERO, MAX, is_zero}` methods.
+  They are based on the same methods in the standard library that stabilized on Rust 1.53.
+
 ## [0.2.1] - 2021-04-06
 
 - [Apply `doc(cfg(...))` on feature gated APIs.](https://github.com/taiki-e/easytime/pull/23)

--- a/build.rs
+++ b/build.rs
@@ -21,4 +21,7 @@ fn main() {
     if cfg.probe_rustc_version(1, 39) {
         println!("cargo:rustc-cfg=stable_1_39");
     }
+    if cfg.probe_rustc_version(1, 53) {
+        println!("cargo:rustc-cfg=stable_1_53");
+    }
 }

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -45,8 +45,39 @@ pub struct Duration(pub(crate) Option<time::Duration>);
 
 impl Duration {
     // TODO: duration_constants https://github.com/rust-lang/rust/issues/57391
-    // TODO: duration_zero https://github.com/rust-lang/rust/issues/73544
     // TODO: div_duration https://github.com/rust-lang/rust/issues/63139
+
+    /// A duration of zero time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use easytime::Duration;
+    ///
+    /// let duration = Duration::ZERO;
+    /// assert!(duration.is_zero());
+    /// assert_eq!(duration.as_nanos(), Some(0));
+    /// ```
+    pub const ZERO: Self = Self::from_nanos(0);
+
+    /// The maximum duration.
+    ///
+    /// This constant is only available on Rust 1.53 and later.
+    ///
+    /// May vary by platform as necessary. Must be able to contain the difference between
+    /// two instances of `Instant` or two instances of `SystemTime`.
+    /// This constraint gives it a value of about 584,942,417,355 years in practice,
+    /// which is currently used on all platforms.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use easytime::Duration;
+    ///
+    /// assert_eq!(Duration::MAX, Duration::new(u64::MAX, 1_000_000_000 - 1));
+    /// ```
+    #[cfg(stable_1_53)]
+    pub const MAX: Self = Self(Some(time::Duration::MAX));
 
     /// Creates a new `Duration` from the specified number of whole seconds and
     /// additional nanoseconds.
@@ -134,6 +165,53 @@ impl Duration {
     #[inline]
     pub const fn from_nanos(nanos: u64) -> Self {
         Self(Some(time::Duration::from_nanos(nanos)))
+    }
+
+    /// Returns true if this `Duration` spans no time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use easytime::Duration;
+    ///
+    /// assert!(Duration::ZERO.is_zero());
+    /// assert!(Duration::new(0, 0).is_zero());
+    /// assert!(Duration::from_nanos(0).is_zero());
+    /// assert!(Duration::from_secs(0).is_zero());
+    ///
+    /// assert!(!Duration::new(1, 1).is_zero());
+    /// assert!(!Duration::from_nanos(1).is_zero());
+    /// assert!(!Duration::from_secs(1).is_zero());
+    /// ```
+    #[inline]
+    #[cfg(stable_1_53)]
+    pub const fn is_zero(&self) -> bool {
+        match &self.0 {
+            Some(d) => d.is_zero(),
+            None => false,
+        }
+    }
+
+    /// Returns true if this `Duration` spans no time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use easytime::Duration;
+    ///
+    /// assert!(Duration::ZERO.is_zero());
+    /// assert!(Duration::new(0, 0).is_zero());
+    /// assert!(Duration::from_nanos(0).is_zero());
+    /// assert!(Duration::from_secs(0).is_zero());
+    ///
+    /// assert!(!Duration::new(1, 1).is_zero());
+    /// assert!(!Duration::from_nanos(1).is_zero());
+    /// assert!(!Duration::from_secs(1).is_zero());
+    /// ```
+    #[inline]
+    #[cfg(not(stable_1_53))]
+    pub fn is_zero(&self) -> bool {
+        self.as_secs() == Some(0) && self.subsec_nanos() == Some(0)
     }
 
     /// Returns the number of _whole_ seconds contained by this `Duration`.

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -1,6 +1,5 @@
 #![warn(rust_2018_idioms, single_use_lifetimes)]
-#![allow(clippy::zero_prefixed_literal)]
-#![allow(clippy::non_ascii_literal)]
+#![allow(clippy::zero_prefixed_literal, clippy::non_ascii_literal, clippy::assertions_on_constants)]
 
 use core::time;
 
@@ -363,8 +362,8 @@ pub mod core_tests {
         const SUB_SEC_NANOS: Option<u32> = DURATION.subsec_nanos();
         assert_eq!(SUB_SEC_NANOS, Some(123_456_789));
 
-        // const IS_ZERO: bool = Duration::ZERO.is_zero();
-        // assert!(IS_ZERO);
+        const IS_ZERO: bool = Duration::ZERO.is_zero();
+        assert!(IS_ZERO);
 
         const SECONDS: Option<u64> = duration_second().as_secs();
         assert_eq!(SECONDS, Some(1));


### PR DESCRIPTION
They are based on the same methods in the standard library that stabilized on Rust 1.53.