### PR TITLE
Add const fn none()

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -47,6 +47,11 @@ impl Duration {
     // TODO: duration_constants https://github.com/rust-lang/rust/issues/57391
     // TODO: div_duration https://github.com/rust-lang/rust/issues/63139
 
+    /// Returns a "none" value
+    pub const fn none() -> Self {
+        Self(None)
+    }
+
     /// A duration of zero time.
     ///
     /// # Examples

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -48,9 +48,7 @@ impl Duration {
     // TODO: div_duration https://github.com/rust-lang/rust/issues/63139
 
     /// Returns a "none" value
-    pub const fn none() -> Self {
-        Self(None)
-    }
+    pub const NONE: Self = Self(None);
 
     /// A duration of zero time.
     ///

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -60,6 +60,11 @@ use super::{pair_and_then, Duration, TryFromTimeError};
 pub struct Instant(Option<time::Instant>);
 
 impl Instant {
+    /// Returns a "none" value
+    pub const fn none() -> Self {
+        Self(None)
+    }
+
     /// Returns an instant corresponding to "now".
     ///
     /// # Examples

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -61,9 +61,7 @@ pub struct Instant(Option<time::Instant>);
 
 impl Instant {
     /// Returns a "none" value
-    pub const fn none() -> Self {
-        Self(None)
-    }
+    pub const NONE: Self = Self(None);
 
     /// Returns an instant corresponding to "now".
     ///

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -6,6 +6,11 @@ use core::time;
 use easytime::Duration;
 
 #[test]
+fn none() {
+    assert!(Duration::none().is_none());
+}
+
+#[test]
 fn cmp() {
     assert!(Duration::from_secs(1) == Duration::from_secs(1));
     assert!(Duration::from_secs(1) != Duration::from_secs(0));

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -7,7 +7,7 @@ use easytime::Duration;
 
 #[test]
 fn none() {
-    assert!(Duration::none().is_none());
+    assert!(Duration::NONE.is_none());
 }
 
 #[test]

--- a/tests/instant.rs
+++ b/tests/instant.rs
@@ -22,6 +22,11 @@ pub mod std_tests {
     }
 
     #[test]
+    fn none() {
+        assert!(Instant::none().is_none());
+    }
+
+    #[test]
     fn instant_monotonic() {
         let a = Instant::now();
         let b = Instant::now();

--- a/tests/instant.rs
+++ b/tests/instant.rs
@@ -23,7 +23,7 @@ pub mod std_tests {
 
     #[test]
     fn none() {
-        assert!(Instant::none().is_none());
+        assert!(Instant::NONE.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Both `Duration` and `Instant` are explicitly optional types, so why not add this?

Alternative: add `NONE` as an associated constant. Simpler, but less flexible in case the internal representation changes.

Workaround: both support `From<Option<..>>` already.